### PR TITLE
Fail on error 1/2 (merge only when not lints left!)

### DIFF
--- a/bin/eslint-crewmeister.js
+++ b/bin/eslint-crewmeister.js
@@ -6,4 +6,6 @@ var eslintConfig = path.join(__dirname, '..', 'index.js');
 
 var argv = process.argv;
 argv.push('--config=' + eslintConfig);
-cli.execute(argv);
+
+var result = cli.execute(argv);
+process.exit(result);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-crewmeister",
-  "version": "2.5.2",
+  "version": "3.0.0",
   "description": "The eslint config we use at crewmeister.",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
So we can make the CI process fail when linter fails.
Should not be merged before all lints fixes are merged and green.