### PR TITLE
Fail on `*.only` usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ module.exports = {
     './rules/globals',
     './rules/modules',
     './rules/flow',
+    './rules/tests',
   ].map(require.resolve),
   parser: 'babel-eslint',
   rules: {},

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "eslint": "^3.4.0",
     "eslint-plugin-flowtype": "^2.15.0",
     "eslint-plugin-import": "^1.16.0",
+    "eslint-plugin-no-only-tests": "^1.1.0",
     "eslint-plugin-react": "^6.2.0"
   }
 }

--- a/rules/tests.js
+++ b/rules/tests.js
@@ -1,0 +1,8 @@
+module.exports = {
+  'plugins': [
+    'no-only-tests'
+  ],
+  'rules': {
+    'no-only-tests/no-only-tests': 2
+  }
+};


### PR DESCRIPTION
Fail lint run when it finds `it.only` or `describe.only`, so we can ensure that ALL tests are always being run in the CI env.