### PR TITLE
Additional React eslint rules.

### DIFF
--- a/rules/es6.js
+++ b/rules/es6.js
@@ -7,7 +7,7 @@ module.exports = {
     // http://eslint.org/docs/rules/arrow-body-style
     'arrow-body-style': 0,
     // require parens in arrow function arguments
-    'arrow-parens': 0,
+    'arrow-parens': [2, 'always'],
     // require space before/after arrow function's arrow
     // https://github.com/eslint/eslint/blob/master/docs/rules/arrow-spacing.md
     'arrow-spacing': [2, { 'before': true, 'after': true }],

--- a/rules/react.js
+++ b/rules/react.js
@@ -21,7 +21,7 @@ module.exports = {
     'react/jsx-closing-bracket-location': [2, 'line-aligned'],
     // Enforce or disallow spaces inside of curly braces in JSX attributes
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-curly-spacing.md
-    'react/jsx-curly-spacing': [2, 'always', { 'allowMultiline': true }],
+    'react/jsx-curly-spacing': [2, 'always', { 'allowMultiline': true, 'spacing': {'objectLiterals': 'never'} }],
     // Enforce event handler naming conventions in JSX
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-handler-names.md
     'react/jsx-handler-names': [0, {

--- a/rules/react.js
+++ b/rules/react.js
@@ -21,7 +21,7 @@ module.exports = {
     'react/jsx-closing-bracket-location': [2, 'line-aligned'],
     // Enforce or disallow spaces inside of curly braces in JSX attributes
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-curly-spacing.md
-    'react/jsx-curly-spacing': [0, 'never', { 'allowMultiline': true }],
+    'react/jsx-curly-spacing': [2, 'always', { 'allowMultiline': true }],
     // Enforce event handler naming conventions in JSX
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-handler-names.md
     'react/jsx-handler-names': [0, {
@@ -42,7 +42,7 @@ module.exports = {
     'react/jsx-no-bind': 0,
     // Prevent duplicate props in JSX
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-duplicate-props.md
-    'react/jsx-no-duplicate-props': [0, { 'ignoreCase': false }],
+    'react/jsx-no-duplicate-props': [2, { 'ignoreCase': false }],
     // Prevent usage of unwrapped JSX strings
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-literals.md
     'react/jsx-no-literals': 0,
@@ -51,7 +51,7 @@ module.exports = {
     'react/jsx-no-undef': 2,
     // Enforce PascalCase for user-defined JSX components
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-pascal-case.md
-    'react/jsx-pascal-case': 0,
+    'react/jsx-pascal-case': 2,
     // Enforce propTypes declarations alphabetical sorting
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-sort-prop-types.md
     'react/jsx-sort-prop-types': [0, {


### PR DESCRIPTION
I know that I'm really petty on those eslint rules but it should make our code more concise.
The biggest change is https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-curly-spacing.md

The other 2 rules react/jsx-no-duplicate-props and react/jsx-pascal-case shouldn't be any issue for us at all. 
